### PR TITLE
Fixed bug in default culture setting for datetime format

### DIFF
--- a/src/EtlLib.Nodes.CsvFiles/CsvWriterNode.cs
+++ b/src/EtlLib.Nodes.CsvFiles/CsvWriterNode.cs
@@ -27,7 +27,7 @@ namespace EtlLib.Nodes.CsvFiles
             _culture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
             _culture.DateTimeFormat.FullDateTimePattern = "yyyy-MM-dd HH:mm:ss.fff";
             _culture.DateTimeFormat.ShortDatePattern = "yyyy-MM-dd";
-            _culture.DateTimeFormat.ShortTimePattern = "HH:mm:ss";
+            _culture.DateTimeFormat.LongTimePattern = "HH:mm:ss.fff";
         }
 
         public CsvWriterNode IncludeHeader(bool includeHeaders = true)


### PR DESCRIPTION
Now dates will have milliseconds by default.